### PR TITLE
Add multiline support

### DIFF
--- a/templates/filebeat.yml.erb
+++ b/templates/filebeat.yml.erb
@@ -6,6 +6,12 @@ filebeat:
 <% prospector['paths'].each do |path| -%>
         - <%= path %>
 <% end -%>
+<% if prospector['multiline_pattern'] and prospector['multiline_match'] and prospector['multiline_negate'] -%>
+      multiline:
+        pattern: "<%= prospector['multiline_pattern'] %>"
+        match: "<%= prospector['multiline_match'] %>"
+        negate: <%= prospector['multiline_negate'] %>
+<% end -%>
 <% if prospector['input_type'] -%>
       input_type: <%= prospector['input_type'] %>
 <% end -%>


### PR DESCRIPTION
Adds the options multiline_match, multiline_negate and multiline_pattern, which can be used on a prospector to configure multiline matching.